### PR TITLE
UnsupportedOperationException: JsonNull in MangaParsers.parseAvailableTranslatedLanguages

### DIFF
--- a/javadex/src/main/java/dev/kurumidisciples/javadex/internal/parsers/MangaParsers.java
+++ b/javadex/src/main/java/dev/kurumidisciples/javadex/internal/parsers/MangaParsers.java
@@ -31,11 +31,12 @@ public class MangaParsers {
     public static List<String> parseAvailableTranslatedLanguages(JsonArray availableTranslatedLanguagesArray) {
         List<String> languages = new ArrayList<>();
         for (JsonElement langElement : availableTranslatedLanguagesArray) {
-            languages.add(langElement.getAsString());
+            if (!langElement.isJsonNull()) {
+                languages.add(langElement.getAsString());
+            }
         }
         return languages;
     }
-
     /**
      * <p>parseTags.</p>
      *


### PR DESCRIPTION
Fixes issue in where parsing translatedLanguages would cause a JsonNull.